### PR TITLE
bug: Add padding to show full side bar

### DIFF
--- a/packages/client/src/components/SideBar.component.tsx
+++ b/packages/client/src/components/SideBar.component.tsx
@@ -96,6 +96,7 @@ export const SideBar: FC<SideBarProps> = ({ open, drawerWidth }) => {
           backgroundColor: '#103F68',
           color: 'white',
           paddingTop: 2,
+          paddingBottom: 10,
           mt: '64px'
         }
       }}


### PR DESCRIPTION
- add padding to show full side bar

before fix
![before-bar-fix](https://github.com/ASL-LEX/SignLab2/assets/110482027/f07e1f11-c37e-43ae-bd6f-50bdbb3dad0a)


after fix
![after-bar-fix](https://github.com/ASL-LEX/SignLab2/assets/110482027/bc141eb6-3a33-4f1c-8ebc-070c36745843)
