### PR TITLE
chore: JWT Cleanup

### DIFF
--- a/packages/server/src/jwt/jwt.guard.ts
+++ b/packages/server/src/jwt/jwt.guard.ts
@@ -3,7 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { GqlExecutionContext } from '@nestjs/graphql';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('local') {
+export class JwtAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
     // Return HTTP context
     if (context.getType() === 'http') {

--- a/packages/server/src/jwt/jwt.module.ts
+++ b/packages/server/src/jwt/jwt.module.ts
@@ -18,7 +18,7 @@ import { JwtSecretRequestType, JwtModule as NestJwtModule } from '@nestjs/jwt';
       useFactory: (jwtService: JwtService) => ({
         secretOrKeyProvider: async (requestType, rawJwtToken) => {
           // Can only verify tokens via the Google public key
-          switch(requestType) {
+          switch (requestType) {
             case JwtSecretRequestType.SIGN:
               throw new Error('Cannot sign tokens');
             case JwtSecretRequestType.VERIFY:
@@ -32,7 +32,7 @@ import { JwtSecretRequestType, JwtModule as NestJwtModule } from '@nestjs/jwt';
           }
         }
       })
-    }),
+    })
   ],
   providers: [JwtService, JwtAuthGuard, JwtStrategy],
   exports: [JwtService]

--- a/packages/server/src/jwt/jwt.module.ts
+++ b/packages/server/src/jwt/jwt.module.ts
@@ -1,13 +1,39 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module, UnauthorizedException, forwardRef } from '@nestjs/common';
 import { JwtService } from './jwt.service';
 import { HttpModule } from '@nestjs/axios';
 import { JwtAuthGuard } from './jwt.guard';
 import { JwtStrategy } from './jwt.strategy';
 import { OrganizationModule } from '../organization/organization.module';
 import { UserOrgModule } from '../userorg/userorg.module';
+import { JwtSecretRequestType, JwtModule as NestJwtModule } from '@nestjs/jwt';
 
 @Module({
-  imports: [HttpModule, forwardRef(() => OrganizationModule), UserOrgModule],
+  imports: [
+    HttpModule,
+    forwardRef(() => OrganizationModule),
+    UserOrgModule,
+    NestJwtModule.registerAsync({
+      imports: [forwardRef(() => JwtModule)],
+      inject: [JwtService],
+      useFactory: (jwtService: JwtService) => ({
+        secretOrKeyProvider: async (requestType, rawJwtToken) => {
+          // Can only verify tokens via the Google public key
+          switch(requestType) {
+            case JwtSecretRequestType.SIGN:
+              throw new Error('Cannot sign tokens');
+            case JwtSecretRequestType.VERIFY:
+              const publicKey = await jwtService.getPublicKey(rawJwtToken);
+              if (!publicKey) {
+                throw new UnauthorizedException('No public key found for token');
+              }
+              return publicKey;
+            default:
+              throw new Error('Invalid request type');
+          }
+        }
+      })
+    }),
+  ],
   providers: [JwtService, JwtAuthGuard, JwtStrategy],
   exports: [JwtService]
 })

--- a/packages/server/src/jwt/jwt.service.ts
+++ b/packages/server/src/jwt/jwt.service.ts
@@ -21,10 +21,27 @@ export class JwtService {
     return response.data;
   }
 
-  async getPublicKey(kid: string): Promise<string | null> {
+  async getPublicKey(rawToken: string | null | Buffer | object): Promise<string | null> {
+    if (!rawToken) {
+      return null;
+    }
+    if (typeof rawToken === 'object') {
+      return null;
+    }
+
+    const token = jwt.decode(rawToken, { complete: true });
+    if (!token) {
+      return null;
+    }
+    const kid = token.header.kid;
+    if (!kid) {
+      return null;
+    }
+
     if (!this.publicKeys || !this.publicKeys[kid]) {
       this.publicKeys = await this.queryForPublicKey();
     }
+
     return this.publicKeys[kid] || null;
   }
 

--- a/packages/server/src/jwt/jwt.strategy.ts
+++ b/packages/server/src/jwt/jwt.strategy.ts
@@ -28,11 +28,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       });
   }
 
-  /**
-   * Need to add the organization at this step since the organization is
-   * queried from the database and not part of the JWT token. This allows
-   * the organization to then be pulled in via the organization context
-   */
   async validate(payload: TokenPayload): Promise<TokenPayload> {
     return {
       ...payload

--- a/packages/server/src/jwt/jwt.strategy.ts
+++ b/packages/server/src/jwt/jwt.strategy.ts
@@ -11,9 +11,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKeyProvider: (_request: Request, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void) => {
+      secretOrKeyProvider: (
+        _request: Request,
+        rawJwtToken: any,
+        done: (err: any, secretOrKey?: string | Buffer) => void
+      ) => {
         // Can only verify tokens via the Google public key
-        jwtService.getPublicKey(rawJwtToken)
+        jwtService
+          .getPublicKey(rawJwtToken)
           .then((publicKey) => {
             if (!publicKey) {
               done(new Error('No public key found for token'));
@@ -24,8 +29,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
           .catch((err) => {
             done(err);
           });
-        }
-      });
+      }
+    });
   }
 
   async validate(payload: TokenPayload): Promise<TokenPayload> {


### PR DESCRIPTION
* Revert to JWT passport strategy
* Leverage `secretOrKeyProvider` functionality